### PR TITLE
Add $install_curl module param

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Acceptance tests works with **puppetlabs/java** in both CentOS and Debian.
 ## Module defaults
 - version           8.2.1
 - install_source    http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz
+- install_curl      true
 - java_home         /usr/java/jdk1.7.0_75/ (default dir for oracle official rpm)
 - manage_user       true
 - group             wildfly

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 class wildfly(
   $version           = '8.2.1',
   $install_source    = 'http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz',
+  $install_curl      = $wildfly::params::install_curl,
   $java_home         = $wildfly::params::java_home,
   $manage_user       = $wildfly::params::manage_user,
   $uid               = $wildfly::params::uid,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@
 #
 class wildfly::params {
 
+  $install_curl = true
   $manage_user  = true
   $uid          = undef
   $gid          = undef

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -43,7 +43,7 @@ class wildfly::prepare {
     }
   }
 
-  if !defined(Package['curl']) {
+  if $wildfly::install_curl {
     package { 'curl':
       ensure => present,
     }


### PR DESCRIPTION
This is safer than using "if !defined()" or "ensure_resource".

Consider the following two test fragments:

Using defined() fails to notice when we've previously set ensure => purged.
```
# Somewhere in profiles::base::packages.pp:
package { 'curl': ensure => purged }
# ... then later, in the wildfly module...
if ! defined(Package['curl']) {
  package { 'curl': ensure => present }
}
```

Using ensure_resource() conflicts with a previously set ensure => latest.
```
# Somewhere in profiles::base::packages.pp:
package { 'curl': ensure => latest }
# ... then later, in the wildfly module...
ensure_resource('package', 'curl', { 'ensure' => 'present' } )
```

